### PR TITLE
Synchroniser avec le référentiel Maven, intégrer avec les packages GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,12 @@ jobs:
 
     - name: Run tests
       run: mvn test
+
+    - name: Set up GitHub packages authentication
+      run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+
+    - name: Deploy to Maven repository
+      run: mvn deploy -DskipTests
+
+    - name: Deploy to GitHub packages
+      run: mvn deploy -DskipTests -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/Lucixxe/TP6-Devops

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,61 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+          <configuration>
+            <repositoryId>github</repositoryId>
+            <url>https://maven.pkg.github.com/Lucixxe/TP6-Devops</url>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>releases</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/Lucixxe/TP6-Devops</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Ajoutez une configuration pour la synchronisation avec le référentiel Maven et les packages GitHub.

* **Pom.xml**

- Ajoutez la section `<distributionManagement>` pour configurer le référentiel Maven.

- Ajoutez la section `<repositories>` pour configurer les packages GitHub.

- Ajoutez `<plugin>` pour `maven-deploy-plugin` pour déployer sur les packages GitHub.

- Ajoutez `<plugin>` pour `maven-gpg-plugin` pour signer les artefacts.

- Ajoutez `<plugin>` pour `maven-source-plugin` pour joindre le code source.

* **.Github/workflows/ci.yml**

- Ajouter une étape pour configurer l'authentification des packages GitHub.

- Ajouter une étape à déployer dans le référentiel Maven.

- Ajouter une étape à déployer sur les packages GitHub.